### PR TITLE
refactor: GlobalExceptionHandler의 ResponseEntityExceptionHandler 보완

### DIFF
--- a/src/main/kotlin/team_json_delivery/sns_b/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/team_json_delivery/sns_b/global/exception/ErrorCode.kt
@@ -1,8 +1,12 @@
 package team_json_delivery.sns_b.global.exception
 
+import org.springframework.http.HttpStatus
+
 enum class ErrorCode(
+    val status: HttpStatus,
     val code: String,
-    val message: String
+    val message: String,
 ) {
-    NOT_FOUND_POST("NOT_FOUND_POST", "게시글이 존재하지 않습니다."),
+    NOT_FOUND_POST(HttpStatus.NOT_FOUND, "NOT_FOUND_POST", "게시글이 존재하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 에러 발생하였습니다."),
 }

--- a/src/main/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandler.kt
@@ -1,17 +1,52 @@
 package team_json_delivery.sns_b.global.exception
 
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ProblemDetail
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import team_json_delivery.sns_b.domain.post.exception.NotFoundPostException
-import team_json_delivery.sns_b.global.model.response.WebResponse
+import java.lang.Exception
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(NotFoundPostException::class)
-    fun badRequest(e: BusinessException): WebResponse<Any> {
-        return WebResponse.error(e.errorCode)
+    fun badRequest(
+        ex: NotFoundPostException,
+        request: WebRequest,
+    ): ProblemDetail =
+        createProblemDetail(
+            ex = ex,
+            status = HttpStatus.BAD_REQUEST,
+            defaultDetail = ex.errorCode.message,
+            detailMessageCode = ex.errorCode.code,
+            detailMessageArguments = null,
+            request = request,
+        )
+
+    override fun createProblemDetail(
+        ex: Exception,
+        status: HttpStatusCode,
+        defaultDetail: String,
+        detailMessageCode: String?,
+        detailMessageArguments: Array<out Any>?,
+        request: WebRequest,
+    ): ProblemDetail {
+        val problemDetail =
+            super.createProblemDetail(
+                ex,
+                status,
+                defaultDetail,
+                detailMessageCode,
+                detailMessageArguments,
+                request,
+            )
+
+        if (ex is BusinessException) {
+            problemDetail.setProperty("errorCode", ex.errorCode.code)
+        }
+        return problemDetail
     }
 }

--- a/src/main/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandler.kt
@@ -1,30 +1,43 @@
 package team_json_delivery.sns_b.global.exception
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ProblemDetail
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
-import team_json_delivery.sns_b.domain.post.exception.NotFoundPostException
-import java.lang.Exception
 
 @RestControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
-    @ExceptionHandler(NotFoundPostException::class)
-    fun badRequest(
-        ex: NotFoundPostException,
+    @ExceptionHandler(BusinessException::class)
+    fun businessExceptionHandler(
+        ex: BusinessException,
         request: WebRequest,
     ): ProblemDetail =
         createProblemDetail(
             ex = ex,
-            status = HttpStatus.BAD_REQUEST,
+            status = ex.errorCode.status,
             defaultDetail = ex.errorCode.message,
             detailMessageCode = ex.errorCode.code,
             detailMessageArguments = null,
             request = request,
         )
+
+    @ExceptionHandler(Exception::class)
+    fun exceptionHandler(
+        ex: RuntimeException,
+        request: WebRequest,
+    ): ProblemDetail {
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+        return createProblemDetail(
+            ex = ex,
+            status = errorCode.status,
+            defaultDetail = errorCode.message,
+            detailMessageCode = errorCode.code,
+            detailMessageArguments = null,
+            request = request,
+        )
+    }
 
     override fun createProblemDetail(
         ex: Exception,
@@ -45,8 +58,12 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
             )
 
         if (ex is BusinessException) {
-            problemDetail.setProperty("errorCode", ex.errorCode.code)
+            problemDetail.setProperty(ERROR_CODE, ex.errorCode.code)
         }
         return problemDetail
+    }
+
+    companion object {
+        const val ERROR_CODE = "errorCode"
     }
 }

--- a/src/test/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,44 @@
+package team_json_delivery.sns_b.global.exception
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team_json_delivery.sns_b.domain.post.exception.NotFoundPostException
+
+@WebMvcTest(GlobalExceptionHandlerTestController::class)
+class GlobalExceptionHandlerTest(
+    private val mockMvc: MockMvc,
+) : DescribeSpec({
+
+        describe("NotFoundPostException 호출") {
+            it("BadRequest 호출") {
+                mockMvc
+                    .perform(get("/notfoundpost"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest)
+            }
+        }
+
+        describe("지원하지 않는 Method 형식 호출") {
+            it("BadRequest 호출") {
+                mockMvc
+                    .perform(post("/notfoundpost"))
+                    .andDo(print())
+                    .andExpect(status().isMethodNotAllowed)
+            }
+        }
+    })
+
+@RestController
+@RequestMapping
+class GlobalExceptionHandlerTestController {
+    @GetMapping("/notfoundpost")
+    fun badRequest(): String = throw NotFoundPostException()
+}

--- a/src/test/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/team_json_delivery/sns_b/global/exception/GlobalExceptionHandlerTest.kt
@@ -6,11 +6,14 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.isEqualTo
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team_json_delivery.sns_b.domain.post.exception.NotFoundPostException
+import team_json_delivery.sns_b.global.exception.GlobalExceptionHandler.Companion.ERROR_CODE
 
 @WebMvcTest(GlobalExceptionHandlerTestController::class)
 class GlobalExceptionHandlerTest(
@@ -18,11 +21,23 @@ class GlobalExceptionHandlerTest(
 ) : DescribeSpec({
 
         describe("NotFoundPostException 호출") {
-            it("BadRequest 호출") {
+            it("호출") {
+                val ex = NotFoundPostException()
                 mockMvc
                     .perform(get("/notfoundpost"))
                     .andDo(print())
-                    .andExpect(status().isBadRequest)
+                    .andExpect(status().isEqualTo(ex.errorCode.status.value()))
+                    .andExpect(jsonPath("$.$ERROR_CODE").value(ex.errorCode.code))
+            }
+        }
+
+        describe("RuntimeException 호출") {
+            it("ErrorCode.INTERNAL_SERVER_ERROR 호출") {
+                val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+                mockMvc
+                    .perform(get("/exception"))
+                    .andDo(print())
+                    .andExpect(status().isEqualTo(errorCode.status.value()))
             }
         }
 
@@ -40,5 +55,8 @@ class GlobalExceptionHandlerTest(
 @RequestMapping
 class GlobalExceptionHandlerTestController {
     @GetMapping("/notfoundpost")
-    fun badRequest(): String = throw NotFoundPostException()
+    fun notfoundpost(): String = throw NotFoundPostException()
+
+    @GetMapping("/exception")
+    fun exception(): String = throw RuntimeException()
 }


### PR DESCRIPTION
- GlobalExceptionHandler에 대해 ProblemDetail 적용하였습니다. 보고 피드백 주세요
- GlobalExceptionHandlerTest 테스트 코드 보시면 저희가 작성한 Excepion handler 코드와 ResponseEntityExceptionHandler에서 기본 지원해주는 handller에 대해 확인해보실 수 있습니다.
- 공통 영역인데 늦게 올린 점 죄송합니다.